### PR TITLE
Extend `Route` atttribute with extra route options

### DIFF
--- a/src/Api/Route.php
+++ b/src/Api/Route.php
@@ -26,20 +26,47 @@ final class Route implements JsonSerializable
      */
     private array $middleware;
 
+    private ?string $host;
+
+    /**
+     * @var string[]
+     */
+    private array $schemes;
+
+    private ?int $httpPort;
+    private ?int $httpsPort;
+
+    /**
+     * @var array<string, mixed>
+     */
+    private array $options;
+
     /**
      * @param string|string[] $method
      * @param string|string[] $middleware
+     * @param string|string[] $schemes
+     * @param array<string, mixed> $options
      */
     public function __construct(
         string $pattern,
         string | array $method = [RequestMethod::GET],
         string $name = null,
-        string | array $middleware = []
+        string | array $middleware = [],
+        string $host = null,
+        string | array $schemes = [],
+        int $httpPort = null,
+        int $httpsPort = null,
+        array $options = []
     ) {
         $this->pattern    = $pattern;
         $this->methods    = is_string($method) === true ? [$method] : $method;
         $this->name       = $name;
         $this->middleware = is_string($middleware) === true ? [$middleware] : $middleware;
+        $this->host       = $host;
+        $this->schemes    = is_string($schemes) === true ? [$schemes] : $schemes;
+        $this->httpPort   = $httpPort;
+        $this->httpsPort  = $httpsPort;
+        $this->options    = $options;
     }
 
     /**
@@ -51,7 +78,12 @@ final class Route implements JsonSerializable
             $payload['pattern'],
             $payload['methods'],
             $payload['name'],
-            $payload['middleware']
+            $payload['middleware'],
+            $payload['host'],
+            $payload['schemes'],
+            $payload['httpPort'],
+            $payload['httpsPort'],
+            $payload['options']
         );
     }
 
@@ -81,6 +113,37 @@ final class Route implements JsonSerializable
         return $this->middleware;
     }
 
+    public function getHost(): ?string
+    {
+        return $this->host;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getSchemes(): array
+    {
+        return $this->schemes;
+    }
+
+    public function getHttpPort(): ?int
+    {
+        return $this->httpPort;
+    }
+
+    public function getHttpsPort(): ?int
+    {
+        return $this->httpsPort;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getOptions(): array
+    {
+        return $this->options;
+    }
+
     /**
      * @return array<string,mixed>
      */
@@ -91,6 +154,11 @@ final class Route implements JsonSerializable
             'methods'    => $this->methods,
             'name'       => $this->name,
             'middleware' => $this->middleware,
+            'host'       => $this->host,
+            'schemes'    => $this->schemes,
+            'httpPort'   => $this->httpPort,
+            'httpsPort'  => $this->httpsPort,
+            'options'    => $this->options,
         ];
     }
 }

--- a/tests/Api/RouteTest.php
+++ b/tests/Api/RouteTest.php
@@ -52,7 +52,12 @@ final class RouteTest extends TestCase
             '/full-fledged',
             [RequestMethod::GET, RequestMethod::POST],
             'full-fledged.route',
-            [stdClass::class, stdClass::class]
+            [stdClass::class, stdClass::class],
+            'localhost',
+            'http',
+            80,
+            null,
+            ['strategy' => 'something']
         );
 
         $this->assertSame([
@@ -60,6 +65,11 @@ final class RouteTest extends TestCase
             'methods'    => [RequestMethod::GET, RequestMethod::POST],
             'name'       => 'full-fledged.route',
             'middleware' => [stdClass::class, stdClass::class],
+            'host'       => 'localhost',
+            'schemes'    => ['http'],
+            'httpPort'   => 80,
+            'httpsPort'  => null,
+            'options'    => ['strategy' => 'something'],
         ], $route->jsonSerialize());
     }
 
@@ -70,11 +80,21 @@ final class RouteTest extends TestCase
             'methods'    => [RequestMethod::GET, RequestMethod::POST],
             'name'       => 'full-fledged.route',
             'middleware' => [stdClass::class, stdClass::class],
+            'host'       => 'localhost',
+            'schemes'    => ['http', 'https'],
+            'httpPort'   => 80,
+            'httpsPort'  => 443,
+            'options'    => ['strategy' => 'something'],
         ]);
 
         $this->assertSame('/full-fledged', $route->getPattern());
         $this->assertSame([RequestMethod::GET, RequestMethod::POST], $route->getMethods());
         $this->assertSame('full-fledged.route', $route->getName());
         $this->assertSame([stdClass::class, stdClass::class], $route->getMiddleware());
+        $this->assertSame('localhost', $route->getHost());
+        $this->assertSame(['http', 'https'], $route->getSchemes());
+        $this->assertSame(80, $route->getHttpPort());
+        $this->assertSame(443, $route->getHttpsPort());
+        $this->assertSame(['strategy' => 'something'], $route->getOptions());
     }
 }

--- a/tests/RouteLoader/Cache/MapCachePayloadToLoadedRoutesTraitTest.php
+++ b/tests/RouteLoader/Cache/MapCachePayloadToLoadedRoutesTraitTest.php
@@ -30,7 +30,17 @@ final class MapCachePayloadToLoadedRoutesTraitTest extends TestCase
             new LoadedRoute(
                 StubClass::class,
                 '__invoke',
-                new Route('/root', RequestMethod::GET, 'root', [StubClass4::class, StubClass3::class])
+                new Route(
+                    '/root',
+                    RequestMethod::GET,
+                    'root',
+                    [StubClass4::class, StubClass3::class],
+                    'localhost',
+                    ['http'],
+                    80,
+                    null,
+                    ['strategy' => 'something']
+                )
             ),
             new LoadedRoute(
                 StubClass2::class,

--- a/tests/RouteLoader/Cache/MapLoadedRoutesToCachePayloadTraitTest.php
+++ b/tests/RouteLoader/Cache/MapLoadedRoutesToCachePayloadTraitTest.php
@@ -26,7 +26,17 @@ final class MapLoadedRoutesToCachePayloadTraitTest extends TestCase
             new LoadedRoute(
                 StubClass::class,
                 '__invoke',
-                new Route('/root', RequestMethod::GET, 'root', [StubClass4::class, StubClass3::class])
+                new Route(
+                    '/root',
+                    RequestMethod::GET,
+                    'root',
+                    [StubClass4::class, StubClass3::class],
+                    'localhost',
+                    ['http'],
+                    80,
+                    null,
+                    ['strategy' => 'something']
+                )
             ),
             new LoadedRoute(
                 StubClass2::class,

--- a/tests/resources/payload.json
+++ b/tests/resources/payload.json
@@ -11,7 +11,14 @@
             "middleware": [
                 "Jerowork\\RouteAttributeProvider\\Test\\resources\\directory\\sub\\StubClass4",
                 "Jerowork\\RouteAttributeProvider\\Test\\resources\\directory\\StubClass3"
-            ]
+            ],
+            "host": "localhost",
+            "schemes": ["http"],
+            "httpPort": 80,
+            "httpsPort":  null,
+            "options": {
+                "strategy": "something"
+            }
         }
     },
     {
@@ -23,7 +30,12 @@
                 "GET"
             ],
             "name": null,
-            "middleware": []
+            "middleware": [],
+            "host": null,
+            "schemes": [],
+            "httpPort": null,
+            "httpsPort":  null,
+            "options": []
         }
     }
 ]


### PR DESCRIPTION
# Description
Including host, schemes (http or https), httpPort, httpsPort and a option array for custom configuration.

Resolves #2 