### PR TITLE
Allow route attribute for invokeable class

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Quality Score](https://img.shields.io/scrutinizer/g/jerowork/route-attribute-provider.svg?style=flat-square)](https://scrutinizer-ci.com/g/jerowork/route-attribute-provider)
 [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE)
 [![Packagist Version](https://img.shields.io/packagist/v/jerowork/route-attribute-provider.svg?style=flat-square&include_prereleases)](https://packagist.org/packages/jerowork/route-attribute-provider)
-[![PHP Version](https://img.shields.io/badge/php-%5E8.0-8892BF.svg?style=flat-square)](http://www.php.net)
+[![PHP Version](https://img.shields.io/badge/php-%5E8.0.2-8892BF.svg?style=flat-square)](http://www.php.net)
 
 Define routes by PHP8 [attributes]((https://stitcher.io/blog/attributes-in-php-8)).
 

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": "^8.0",
         "jerowork/file-class-reflector": "^0.1.0",
-        "psr/simple-cache": "^1.0"
+        "psr/simple-cache": "^1.0 || ^3.0"
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.15",

--- a/composer.json
+++ b/composer.json
@@ -1,13 +1,13 @@
 {
     "name": "jerowork/route-attribute-provider",
-    "type": "library",
     "description": "Define routes by PHP8 attributes",
+    "license": "MIT",
+    "type": "library",
     "keywords": [
         "php8",
         "attributes",
         "router"
     ],
-    "license": "MIT",
     "authors": [
         {
             "name": "Jeroen de Graaf",
@@ -35,12 +35,6 @@
     "suggest": {
         "symfony/cache": "As PSR-16 Cache implementation"
     },
-    "config": {
-        "platform": {
-            "php": "8.0"
-        },
-        "sort-packages": true
-    },
     "autoload": {
         "psr-4": {
             "Jerowork\\RouteAttributeProvider\\": "src/"
@@ -50,5 +44,15 @@
         "psr-4": {
             "Jerowork\\RouteAttributeProvider\\Test\\": "tests/"
         }
+    },
+    "config": {
+        "allow-plugins": {
+            "phpro/grumphp-shim": true,
+            "ergebnis/composer-normalize": true
+        },
+        "platform": {
+            "php": "8.0"
+        },
+        "sort-packages": true
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,9 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.0.2",
         "jerowork/file-class-reflector": "^0.1.0",
-        "psr/simple-cache": "^1.0 || ^3.0"
+        "psr/simple-cache": "^1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.15",
@@ -29,7 +29,7 @@
         "phpunit/phpunit": "^9.5",
         "scrutinizer/ocular": "^1.8",
         "squizlabs/php_codesniffer": "^3.6",
-        "symfony/cache": "^5.3",
+        "symfony/cache": "^6.0",
         "vimeo/psalm": "^4.9"
     },
     "suggest": {
@@ -51,7 +51,7 @@
             "ergebnis/composer-normalize": true
         },
         "platform": {
-            "php": "8.0"
+            "php": "8.0.2"
         },
         "sort-packages": true
     }

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<psalm totallyTyped="false"
+<psalm errorLevel="2"
+       reportMixedIssues="false"
        resolveFromConfigFile="true"
        allowStringToStandInForClass="true"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/src/Api/Route.php
+++ b/src/Api/Route.php
@@ -7,7 +7,7 @@ namespace Jerowork\RouteAttributeProvider\Api;
 use Attribute;
 use JsonSerializable;
 
-#[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
 final class Route implements JsonSerializable
 {
     private string $pattern;

--- a/src/Api/Route.php
+++ b/src/Api/Route.php
@@ -49,11 +49,11 @@ final class Route implements JsonSerializable
      */
     public function __construct(
         string $pattern,
-        string | array $method = [RequestMethod::GET],
+        string|array $method = [RequestMethod::GET],
         string $name = null,
-        string | array $middleware = [],
+        string|array $middleware = [],
         string $host = null,
-        string | array $schemes = [],
+        string|array $schemes = [],
         int $httpPort = null,
         int $httpsPort = null,
         array $options = []

--- a/src/RouteLoader/ClassReflector/ClassReflectorRouteLoader.php
+++ b/src/RouteLoader/ClassReflector/ClassReflectorRouteLoader.php
@@ -39,16 +39,16 @@ final class ClassReflectorRouteLoader implements RouteLoaderInterface
         $reflector = $this->reflectorFactory->create()->addDirectory(...$this->directories);
         foreach ($reflector->reflect()->getClasses() as $class) {
             $hasClassAttribute = false;
-            
+
             foreach ($class->getAttributes(Route::class) as $attribute) {
                 $hasClassAttribute = true;
-                
+
                 /** @var Route $route */
-                $route = $attribute->newInstance();         
-                
+                $route = $attribute->newInstance();
+
                 yield new LoadedRoute($class->getName(), '__invoke', $route);
             }
-            
+
             if (!$hasClassAttribute) {
                 foreach ($class->getMethods() as $method) {
                     foreach ($method->getAttributes(Route::class) as $attribute) {

--- a/tests/RouteAttributeConfiguratorTest.php
+++ b/tests/RouteAttributeConfiguratorTest.php
@@ -11,6 +11,7 @@ use Jerowork\RouteAttributeProvider\RouteLoader\Cache\CacheRouteLoaderDecorator;
 use Jerowork\RouteAttributeProvider\Test\resources\directory\StubClass3;
 use Jerowork\RouteAttributeProvider\Test\resources\directory\sub\StubClass4;
 use Jerowork\RouteAttributeProvider\Test\resources\StubClass;
+use Jerowork\RouteAttributeProvider\Test\resources\StubClass1;
 use Jerowork\RouteAttributeProvider\Test\resources\StubClass2;
 use Mockery;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
@@ -67,6 +68,18 @@ final class RouteAttributeConfiguratorTest extends MockeryTestCase
                 '__invoke',
                 Mockery::on(function (Route $route): bool {
                     $this->assertSame('/minimalist', $route->getPattern());
+
+                    return true;
+                })
+            );
+            
+        $provider->expects('configure')
+            ->once()
+            ->with(
+                StubClass1::class,
+                '__invoke',
+                Mockery::on(function (Route $route): bool {
+                    $this->assertSame('/retest', $route->getPattern());
 
                     return true;
                 })

--- a/tests/RouteLoader/ClassReflector/ClassReflectorRouteLoaderTest.php
+++ b/tests/RouteLoader/ClassReflector/ClassReflectorRouteLoaderTest.php
@@ -12,6 +12,7 @@ use Jerowork\RouteAttributeProvider\RouteLoader\LoadedRoute;
 use Jerowork\RouteAttributeProvider\Test\resources\directory\StubClass3;
 use Jerowork\RouteAttributeProvider\Test\resources\directory\sub\StubClass4;
 use Jerowork\RouteAttributeProvider\Test\resources\StubClass;
+use Jerowork\RouteAttributeProvider\Test\resources\StubClass1;
 use Jerowork\RouteAttributeProvider\Test\resources\StubClass2;
 use phpDocumentor\Reflection\Php\ProjectFactory;
 use PHPUnit\Framework\TestCase;
@@ -29,7 +30,7 @@ final class ClassReflectorRouteLoaderTest extends TestCase
 
         $loadedRoutes = iterator_to_array($loader->getRoutes());
 
-        $this->assertCount(5, $loadedRoutes);
+        $this->assertCount(6, $loadedRoutes);
 
         /** @var LoadedRoute $loadedRoute */
         $loadedRoute = $loadedRoutes[0];
@@ -40,9 +41,19 @@ final class ClassReflectorRouteLoaderTest extends TestCase
         $this->assertSame([RequestMethod::GET], $loadedRoute->getRoute()->getMethods());
         $this->assertNull($loadedRoute->getRoute()->getName());
         $this->assertSame([], $loadedRoute->getRoute()->getMiddleware());
-
+        
         /** @var LoadedRoute $loadedRoute */
         $loadedRoute = $loadedRoutes[1];
+
+        $this->assertSame(StubClass1::class, $loadedRoute->getClassName());
+        $this->assertSame('__invoke', $loadedRoute->getMethodName());
+        $this->assertSame('/retest', $loadedRoute->getRoute()->getPattern());
+        $this->assertSame([RequestMethod::GET], $loadedRoute->getRoute()->getMethods());
+        $this->assertNull($loadedRoute->getRoute()->getName());
+        $this->assertSame([], $loadedRoute->getRoute()->getMiddleware());
+
+        /** @var LoadedRoute $loadedRoute */
+        $loadedRoute = $loadedRoutes[2];
 
         $this->assertSame(StubClass2::class, $loadedRoute->getClassName());
         $this->assertSame('handle', $loadedRoute->getMethodName());
@@ -52,7 +63,7 @@ final class ClassReflectorRouteLoaderTest extends TestCase
         $this->assertSame([StubClass4::class], $loadedRoute->getRoute()->getMiddleware());
 
         /** @var LoadedRoute $loadedRoute */
-        $loadedRoute = $loadedRoutes[2];
+        $loadedRoute = $loadedRoutes[3];
 
         $this->assertSame(StubClass3::class, $loadedRoute->getClassName());
         $this->assertSame('__invoke', $loadedRoute->getMethodName());
@@ -62,7 +73,7 @@ final class ClassReflectorRouteLoaderTest extends TestCase
         $this->assertSame([StubClass4::class, stdClass::class], $loadedRoute->getRoute()->getMiddleware());
 
         /** @var LoadedRoute $loadedRoute */
-        $loadedRoute = $loadedRoutes[3];
+        $loadedRoute = $loadedRoutes[4];
 
         $this->assertSame(StubClass3::class, $loadedRoute->getClassName());
         $this->assertSame('__invoke', $loadedRoute->getMethodName());
@@ -72,7 +83,7 @@ final class ClassReflectorRouteLoaderTest extends TestCase
         $this->assertSame([], $loadedRoute->getRoute()->getMiddleware());
 
         /** @var LoadedRoute $loadedRoute */
-        $loadedRoute = $loadedRoutes[4];
+        $loadedRoute = $loadedRoutes[5];
 
         $this->assertSame(StubClass4::class, $loadedRoute->getClassName());
         $this->assertSame('__invoke', $loadedRoute->getMethodName());

--- a/tests/resources/StubClass1.php
+++ b/tests/resources/StubClass1.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jerowork\RouteAttributeProvider\Test\resources;
+
+use Jerowork\RouteAttributeProvider\Api\Route;
+
+#[Route('/retest')]
+final class StubClass1
+{
+    public function __invoke(): void
+    {
+    }
+}


### PR DESCRIPTION
Hi,

This is a request to allow the `#[route]` attribute to be used on the class declaration. It will call the `__invoke` method 